### PR TITLE
Fix git tag command, adding a message to it

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ stages:
           git status
           git add -A
           git commit -m "Release v$(PackageVersion)"
-          git tag -a v$(PackageVersion)
+          git tag -a v$(PackageVersion) -m "v$(PackageVersion)"
           git push --follow-tags
 
     - task: NuGetCommand@2


### PR DESCRIPTION
Fix `git tag` command, adding a message to it
This will prevent en editor to opened (apparently `vi` in AzureDevOps windows agent, which explains why I had to manually cancel the build).