### PR TITLE
Prevent exceptions from stopping the execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 
 It provides a 'framework' so that you only have to worry about solving the problems, and measures the performance of your solutions.
 
-Problem example: 
+Problem example:
+
 ```csharp
 using AoCHelper;
 using System.IO;
@@ -56,15 +57,16 @@ Example projects can be found at:
 
 - [AdventOfCode.Template](https://github.com/eduherminio/AdventOfCode.Template)
 - [AoCHelper.PoC](https://github.com/eduherminio/AoCHelper/tree/master/src/AoCHelper.PoC)
+- [AoC2020](https://github.com/eduherminio/AoC2020)
+
+## Tips
+
+Your problem classes are instantiated only once, so parsing the input file (`InputFilePath`) in your class constructor allows you to:
+
+- Avoid executing parsing logic twice per problem.
+- Measure more accurately your part 1 and part 2 solutions performance.
 
 [githubactionslogo]: https://github.com/eduherminio/AoCHelper/workflows/CI/badge.svg
 [githubactionslink]: https://github.com/eduherminio/AoCHelper/actions?query=workflow%3ACI
 [nugetlogo]: https://img.shields.io/nuget/v/AocHelper.svg?style=flat-square&label=nuget
 [nugetlink]: https://www.nuget.org/packages/AocHelper
-
-## Tips
-
-Your problem classes are only instantiated once, so parsing the input file (`InputFilePath`) in your class constructor allows you to:
-
-- Avoid executing parsing logic twice per problem.
-- Measure more accurately your part 1 and part 2 solutions performance.

--- a/src/AoCHelper.PoC/Day01.cs
+++ b/src/AoCHelper.PoC/Day01.cs
@@ -14,12 +14,12 @@ namespace AoCHelper.PoC
 
         public override string Solve_1()
         {
-            System.Threading.Thread.Sleep(33);
             return "Solution 1";
         }
 
         public override string Solve_2()
         {
+            System.Threading.Thread.Sleep(50);
             return "Solution 2";
         }
     }

--- a/src/AoCHelper.PoC/Problem03.cs
+++ b/src/AoCHelper.PoC/Problem03.cs
@@ -14,13 +14,13 @@ namespace AoCHelper.PoC
 
         public override string Solve_1()
         {
-            System.Threading.Thread.Sleep(250);
+            System.Threading.Thread.Sleep(1000);
             return "Solution 1";
         }
 
         public override string Solve_2()
         {
-            System.Threading.Thread.Sleep(1001);
+            System.Threading.Thread.Sleep(1500);
             return "Solution 2";
         }
     }

--- a/src/AoCHelper.PoC/Problem04.cs
+++ b/src/AoCHelper.PoC/Problem04.cs
@@ -22,7 +22,7 @@ namespace AoCHelper.PoC
 
         public override string Solve_2()
         {
-            System.Threading.Thread.Sleep(2001);
+            System.Threading.Thread.Sleep(2000);
             return "Solution 2";
         }
     }

--- a/src/AoCHelper.PoC/RandomProblem.cs
+++ b/src/AoCHelper.PoC/RandomProblem.cs
@@ -25,7 +25,7 @@ namespace AoCHelper.PoC
 
         public override string Solve_2()
         {
-            System.Threading.Thread.Sleep(1501);
+            System.Threading.Thread.Sleep(1500);
             return "Solution 2";
         }
     }

--- a/src/AoCHelper/Solver.cs
+++ b/src/AoCHelper/Solver.cs
@@ -93,16 +93,48 @@ namespace AoCHelper
                 ? $"Day {problemIndex}"
                 : $"{problem.GetType().Name}";
 
-            var stopwatch = Stopwatch.StartNew();
-            var solution1 = problem.Solve_1();
-            stopwatch.Stop();
+            Stopwatch stopwatch = null!;
 
-            RenderRow(table, problemTitle, 1, solution1, stopwatch);
+            var solution1 = string.Empty;
+            try
+            {
+                stopwatch = Stopwatch.StartNew();
+                solution1 = problem.Solve_1();
+            }
+            catch (NotImplementedException)
+            {
+                solution1 = "[[Not implemented]]";
+            }
+            catch (Exception e)
+            {
+                solution1 = e.Message + Environment.NewLine + e.StackTrace;
+            }
+            finally
+            {
+                stopwatch.Stop();
+            }
 
-            stopwatch.Reset();
-            stopwatch.Restart();
-            var solution2 = problem.Solve_2();
-            stopwatch.Stop();
+            RenderRow(table, problemTitle, 1, solution1, stopwatch!);
+
+            var solution2 = string.Empty;
+            try
+            {
+                stopwatch.Reset();
+                stopwatch.Restart();
+                solution2 = problem.Solve_2();
+            }
+            catch (NotImplementedException)
+            {
+                solution2 = "[[Not implemented]]";
+            }
+            catch (Exception e)
+            {
+                solution2 = e.Message + Environment.NewLine + e.StackTrace;
+            }
+            finally
+            {
+                stopwatch.Stop();
+            }
 
             RenderRow(table, problemTitle, 2, solution2, stopwatch);
 
@@ -116,16 +148,18 @@ namespace AoCHelper
             var color = elapsedMilliseconds switch
             {
                 0 => Color.Blue,
-                <= 100 => Color.Lime,
-                <= 500 => Color.GreenYellow,
-                <= 1000 => Color.Yellow1,
-                <= 2000 => Color.OrangeRed1,
+                < 100 => Color.Lime,
+                < 500 => Color.GreenYellow,
+                < 1000 => Color.Yellow1,
+                < 2000 => Color.OrangeRed1,
                 _ => Color.Red1
             };
 
-            var elapsedTime = elapsedMilliseconds < 1000
-                ? $"{elapsedMilliseconds} ms"
-                : $"{0.001 * elapsedMilliseconds:F} s";
+            var elapsedTime = elapsedMilliseconds < 60_000
+                ? elapsedMilliseconds < 1_000
+                    ? $"{elapsedMilliseconds} ms"
+                    : $"{0.001 * elapsedMilliseconds:F} s"
+                : $"{elapsedMilliseconds / 60_000} min {Math.Round(0.001 * (elapsedMilliseconds % 60_000))} s";
 
             table.AddRow(problemTitle, $"Part {part}", solution, $"[{color}]{elapsedTime}[/]");
 

--- a/tests/AoCHelper.Test/OverrideInputFileExtensionTests.cs
+++ b/tests/AoCHelper.Test/OverrideInputFileExtensionTests.cs
@@ -25,17 +25,11 @@ namespace AoCHelper.Test
         private class Problem01 : BaseProblemFixture { protected override string InputFileExtension => nameof(OverrideInputFileExtensionTests); }
         private class Problem_01 : BaseProblemFixture { protected override string InputFileExtension => nameof(OverrideInputFileExtensionTests); }
 
-        private class Problem02 : BaseProblemFixture { protected override string InputFileExtension => nameof(OverrideInputFileExtensionTests); }
-        private class Problem_02 : BaseProblemFixture { protected override string InputFileExtension => nameof(OverrideInputFileExtensionTests); }
-
         [Fact]
         public void OverrideInputFileExtension()
         {
             Solver.Solve<Problem01>();
             Solver.Solve<Problem_01>();
-
-            Assert.Throws<FileNotFoundException>(() => Solver.Solve<Problem02>());
-            Assert.Throws<FileNotFoundException>(() => Solver.Solve<Problem_02>());
         }
     }
 }

--- a/tests/AoCHelper.Test/SolverTest.cs
+++ b/tests/AoCHelper.Test/SolverTest.cs
@@ -35,15 +35,17 @@ namespace AoCHelper.Test
         }
 
         [Fact]
-        public void ShouldNotSolve()
+        public void ShouldNotThrowExceptionIfCantSolve()
         {
-            Assert.Throws<FileNotFoundException>(() => Solver.Solve<IllCreatedCustomProblem>());
+            Solver.Solve<IllCreatedCustomProblem>();
         }
 
         [Fact]
         public void LoadAllProblems()
         {
-            Assert.Equal(14, Solver.LoadAllProblems(Assembly.GetExecutingAssembly()).Count());
+            Assert.Equal(
+                Assembly.GetExecutingAssembly()!.GetTypes().Count(type => typeof(BaseProblem).IsAssignableFrom(type) && !type.IsAbstract),
+                Solver.LoadAllProblems(Assembly.GetExecutingAssembly()).Count());
         }
     }
 }


### PR DESCRIPTION
* Prevent exceptions from stopping the execution (`[Not implemented]` is printed at solution instead).
* Print minutes + seconds if seconds > 60 (`102 s` -> `1 min 42 s`).
* Change color boundaries to be `<` instead of `<=`.