### PR TITLE
Solve by index

### DIFF
--- a/src/AoCHelper/Solver.cs
+++ b/src/AoCHelper/Solver.cs
@@ -33,6 +33,31 @@ namespace AoCHelper
         }
 
         /// <summary>
+        /// Solves those problems whose <see cref="BaseProblem.CalculateIndex"/> method matches one of the provided numbers.
+        /// 0 can be used for those problems whose <see cref="BaseProblem.CalculateIndex"/> returns the default value due to not being able to deduct the index.
+        /// </summary>
+        /// <param name="problemNumbers"></param>
+        public static void Solve(params uint[] problemNumbers) => Solve(problemNumbers.AsEnumerable());
+
+        /// <summary>
+        /// Solves those problems whose <see cref="BaseProblem.CalculateIndex"/> method matches one of the provided numbers.
+        /// 0 can be used for those problems whose <see cref="BaseProblem.CalculateIndex"/> returns the default value due to not being able to deduct the index.
+        /// </summary>
+        /// <param name="problemNumbers"></param>
+        public static void Solve(IEnumerable<uint> problemNumbers)
+        {
+            var table = GetTable();
+
+            foreach (Type problemType in LoadAllProblems(Assembly.GetEntryAssembly()!))
+            {
+                if (Activator.CreateInstance(problemType) is BaseProblem problem && problemNumbers.Contains(problem.CalculateIndex()))
+                {
+                    Solve(problem, table, clearConsole: true);
+                }
+            }
+        }
+
+        /// <summary>
         /// Solves last problem.
         /// It also prints the elapsed time in <see cref="BaseProblem.Solve_1"/> and <see cref="BaseProblem.Solve_2"/> methods.
         /// </summary>
@@ -50,10 +75,7 @@ namespace AoCHelper
         /// Solves the provided problems.
         /// It also prints the elapsed time in <see cref="BaseProblem.Solve_1"/> and <see cref="BaseProblem.Solve_2"/> methods.
         /// </summary>
-        public static void Solve(params Type[] problems)
-        {
-            Solve(problems.AsEnumerable());
-        }
+        public static void Solve(params Type[] problems) => Solve(problems.AsEnumerable());
 
         /// <summary>
         /// Solves the provided problems.

--- a/tests/AoCHelper.Test/SolverTest.cs
+++ b/tests/AoCHelper.Test/SolverTest.cs
@@ -35,13 +35,25 @@ namespace AoCHelper.Test
         }
 
         [Fact]
-        public void SolveParams()
+        public void SolveIntParams()
+        {
+            Solver.Solve(1, 2);
+        }
+
+        [Fact]
+        public void SolveIntEnumerable()
+        {
+            Solver.Solve(new uint[] { 1, 2 });
+        }
+
+        [Fact]
+        public void SolveTypeParams()
         {
             Solver.Solve(typeof(Problem66));
         }
 
         [Fact]
-        public void SolveEnumerable()
+        public void SolveTypeEnumerable()
         {
             Solver.Solve(new[] { typeof(Problem66) });
         }


### PR DESCRIPTION
* Add `Solve(params uint[])` and `Solve(IEnumerable<uint>)`, allowing `Solver` to solve problems by index (according to `BaseProblem.CalculateIndex()`).
This closes #27.