### PR TITLE
Allow higher resolution timings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ namespace AdventOfCode
 
 Output example:
 
-![image](https://user-images.githubusercontent.com/11148519/100517610-0987a880-318c-11eb-897d-6278a440fd44.png)
+![image](https://user-images.githubusercontent.com/11148519/101073364-a0df6800-359f-11eb-8dc8-5542ccc14120.png)
 
 ## :new: AdventOfCode.Template
 
@@ -39,6 +39,13 @@ Creating your Advent of Code repository from [AdventOfCode.Template](https://git
   - Name them `DayXX` or `Day_XX` and make them inherit `BaseDay`.
   - Name them `ProblemXX` or `Problem_XX`and make them inherit `BaseProblem`.
 - **Put your input files under `Inputs/` directory** and follow `XX.txt` naming convention for day `XX`. Make sure to copy those files to your output folder.
+- Choose your **solving strategy** in your `Main()` method:
+  - `Solver.SolveAll();`
+  - `Solver.SolveLast();`
+  - `Solver.SolveLast(clearConsole: false);`
+  - `Solver.Solve<Day_05>();`
+  - `Solver.Solve(5, 6);`
+  - `Solver.Solve(typeof(Day_05), typeof(Day_06));`
 
 ## Advanced usage
 
@@ -51,6 +58,7 @@ You can also:
   - Override `CalculateIndex()` to follow a different `XX` or `_XX` convention in your class names.
   - Override `InputFilePath` to follow a different naming convention in your input files. Check the [current implementation](https://github.com/eduherminio/AoCHelper/blob/master/src/AoCHelper/BaseProblem.cs) to understand how to reuse all the other properties and methods.
 - _[Not recommended]_ Override `InputFilePath` in any specific problem class to point to a concrete file. This will make the values of `ClassPrefix`, `InputFileDirPath` and `InputFileExtension` and the implementation of `CalculateIndex()` irrelevant (see the [current implementation](https://github.com/eduherminio/AoCHelper/blob/master/src/AoCHelper/BaseProblem.cs)).
+- Override `Solver.MillisecondsFormatSpecifier` to provide custom [numeric format strings](https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings) for the elapsed milliseconds.
 
 ## Usage examples
 
@@ -59,6 +67,7 @@ Example projects can be found at:
 - [AdventOfCode.Template](https://github.com/eduherminio/AdventOfCode.Template)
 - [AoCHelper.PoC](https://github.com/eduherminio/AoCHelper/tree/master/src/AoCHelper.PoC)
 - [AoC2020](https://github.com/eduherminio/AoC2020)
+- [All these repositories](https://github.com/eduherminio/AoCHelper/network/dependents)
 
 ## Tips
 

--- a/src/AoCHelper.PoC/Day01.cs
+++ b/src/AoCHelper.PoC/Day01.cs
@@ -19,7 +19,6 @@ namespace AoCHelper.PoC
 
         public override string Solve_2()
         {
-            System.Threading.Thread.Sleep(50);
             return "Solution 2";
         }
     }

--- a/src/AoCHelper.PoC/Day_02.cs
+++ b/src/AoCHelper.PoC/Day_02.cs
@@ -14,13 +14,13 @@ namespace AoCHelper.PoC
 
         public override string Solve_1()
         {
-            System.Threading.Thread.Sleep(250);
+            System.Threading.Thread.Sleep(1);
             return "Solution 1";
         }
 
         public override string Solve_2()
         {
-            System.Threading.Thread.Sleep(750);
+            System.Threading.Thread.Sleep(11);
             return "Solution 2";
         }
     }

--- a/src/AoCHelper.PoC/Problem03.cs
+++ b/src/AoCHelper.PoC/Problem03.cs
@@ -14,13 +14,13 @@ namespace AoCHelper.PoC
 
         public override string Solve_1()
         {
-            System.Threading.Thread.Sleep(1000);
+            System.Threading.Thread.Sleep(101);
             return "Solution 1";
         }
 
         public override string Solve_2()
         {
-            System.Threading.Thread.Sleep(1500);
+            System.Threading.Thread.Sleep(501);
             return "Solution 2";
         }
     }

--- a/src/AoCHelper.PoC/RandomProblem.cs
+++ b/src/AoCHelper.PoC/RandomProblem.cs
@@ -19,13 +19,12 @@ namespace AoCHelper.PoC
 
         public override string Solve_1()
         {
-            System.Threading.Thread.Sleep(500);
             return "Solution 1";
         }
 
         public override string Solve_2()
         {
-            System.Threading.Thread.Sleep(1500);
+            System.Threading.Thread.Sleep(10_000);
             return "Solution 2";
         }
     }

--- a/src/AoCHelper/Solver.cs
+++ b/src/AoCHelper/Solver.cs
@@ -9,6 +9,8 @@ namespace AoCHelper
 {
     public static class Solver
     {
+        public static string? MillisecondsFormatSpecifier { get; set; } = null;
+
         private static readonly bool IsInteractiveEnvironment = Environment.UserInteractive && !Console.IsOutputRedirected;
 
         private static Table GetTable() => new Table()
@@ -193,13 +195,21 @@ namespace AoCHelper
                 _ => Color.Red1
             };
 
-            var elapsedTime = elapsedMilliseconds switch
-            {
-                < 1 => $"{elapsedMilliseconds:F} ms",
-                < 1_000 => $"{Math.Round(elapsedMilliseconds)} ms",
-                < 60_000 => $"{0.001 * elapsedMilliseconds:F} s",
-                _ => $"{elapsedMilliseconds / 60_000} min {Math.Round(0.001 * (elapsedMilliseconds % 60_000))} s",
-            };
+            var elapsedTime = MillisecondsFormatSpecifier is null
+                ? elapsedMilliseconds switch
+                {
+                    < 1 => $"{elapsedMilliseconds:F} ms",
+                    < 1_000 => $"{Math.Round(elapsedMilliseconds)} ms",
+                    < 60_000 => $"{0.001 * elapsedMilliseconds:F} s",
+                    _ => $"{elapsedMilliseconds / 60_000} min {Math.Round(0.001 * (elapsedMilliseconds % 60_000))} s",
+                }
+                : elapsedMilliseconds switch
+                {
+                    < 1 => $"{elapsedMilliseconds.ToString(MillisecondsFormatSpecifier)} ms",
+                    < 1_000 => $"{elapsedMilliseconds.ToString(MillisecondsFormatSpecifier)} ms",
+                    < 60_000 => $"{(0.001 * elapsedMilliseconds).ToString(MillisecondsFormatSpecifier)} s",
+                    _ => $"{elapsedMilliseconds / 60_000} min {(0.001 * (elapsedMilliseconds % 60_000)).ToString(MillisecondsFormatSpecifier)} s",
+                };
 
             table.AddRow(problemTitle, $"Part {part}", solution, $"[{color}]{elapsedTime}[/]");
 

--- a/src/AoCHelper/Solver.cs
+++ b/src/AoCHelper/Solver.cs
@@ -180,23 +180,26 @@ namespace AoCHelper
 
         private static void RenderRow(Table table, string problemTitle, int part, string solution, Stopwatch stopwatch, bool clearConsole)
         {
-            var elapsedMilliseconds = stopwatch.ElapsedMilliseconds;
+            var elapsedMilliseconds = 1000 * stopwatch.ElapsedTicks / (double)Stopwatch.Frequency;
 
             var color = elapsedMilliseconds switch
             {
-                0 => Color.Blue,
+                < 1 => Color.Blue,
+                < 10 => Color.Green1,
                 < 100 => Color.Lime,
                 < 500 => Color.GreenYellow,
-                < 1000 => Color.Yellow1,
-                < 2000 => Color.OrangeRed1,
+                < 1_000 => Color.Yellow1,
+                < 10_000 => Color.OrangeRed1,
                 _ => Color.Red1
             };
 
-            var elapsedTime = elapsedMilliseconds < 60_000
-                ? elapsedMilliseconds < 1_000
-                    ? $"{elapsedMilliseconds} ms"
-                    : $"{0.001 * elapsedMilliseconds:F} s"
-                : $"{elapsedMilliseconds / 60_000} min {Math.Round(0.001 * (elapsedMilliseconds % 60_000))} s";
+            var elapsedTime = elapsedMilliseconds switch
+            {
+                < 1 => $"{elapsedMilliseconds:F} ms",
+                < 1_000 => $"{Math.Round(elapsedMilliseconds)} ms",
+                < 60_000 => $"{0.001 * elapsedMilliseconds:F} s",
+                _ => $"{elapsedMilliseconds / 60_000} min {Math.Round(0.001 * (elapsedMilliseconds % 60_000))} s",
+            };
 
             table.AddRow(problemTitle, $"Part {part}", solution, $"[{color}]{elapsedTime}[/]");
 


### PR DESCRIPTION
* Use `Stopwatch.ElapsedTicks` rather than `Stopwatch.Milliseconds`, and show show 2 decimal digits if the measured time is less than 1ms.

* Add public `Solver.MillisecondsFormatSpecifier` property*, modifyable by anyone that wants to get non-default behavior regarding resolution. It supports [Standard numeric format strings](https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings).

* Re-evaluate elapsed time colors:
  * Add `Color.Green1,` for <10ms.
  * Relax `Color.Red1`: now it's > 10s, and `Color.OrangeRed1` will be in place between 1s and 10s.

This PR closes #30.

\* This solution may not last long as it is, I'm currently considering some kind of `SolvingConfiguration`/`SolvingOptions` class that will contain that and a few other options.