### PR TITLE
Add SolverConfiguration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,79 @@
+[*.cs]
+# CS8603: Possible null reference return.
+dotnet_diagnostic.CS8603.severity = error
+# CS8604: Possible null reference argument.
+dotnet_diagnostic.CS8604.severity = error
+# CS8606: Possible null reference assignment to iteration variable
+dotnet_diagnostic.CS8606.severity = error
+# CS8600: Converting null literal or possible null value to non-nullable type.
+dotnet_diagnostic.CS8600.severity = error
+# CS8602: Dereference of a possibly null reference.
+dotnet_diagnostic.CS8602.severity = error
+# CS8625: Cannot convert null literal to non-nullable reference type.
+dotnet_diagnostic.CS8625.severity = error
+# CS8607: A possible null value may not be passed to a target marked with the [DisallowNull] attribute
+dotnet_diagnostic.CS8607.severity = error
+# CS8608: Nullability of reference types in type doesn't match overridden member.
+dotnet_diagnostic.CS8608.severity = error
+# CS8609: Nullability of reference types in return type doesn't match overridden member.
+dotnet_diagnostic.CS8609.severity = error
+# CS8610: Nullability of reference types in type of parameter doesn't match overridden member.
+dotnet_diagnostic.CS8610.severity = error
+# CS8611: Nullability of reference types in type of parameter doesn't match partial method declaration.
+dotnet_diagnostic.CS8611.severity = error
+# CS8612: Nullability of reference types in type doesn't match implicitly implemented member.
+dotnet_diagnostic.CS8612.severity = error
+# CS8613: Nullability of reference types in return type doesn't match implicitly implemented member.
+dotnet_diagnostic.CS8613.severity = error
+# CS8614: Nullability of reference types in type of parameter doesn't match implicitly implemented member.
+dotnet_diagnostic.CS8614.severity = error
+# CS8615: Nullability of reference types in type doesn't match implemented member.
+dotnet_diagnostic.CS8615.severity = error
+# CS8616: Nullability of reference types in return type doesn't match implemented member.
+dotnet_diagnostic.CS8616.severity = error
+# CS8617: Nullability of reference types in type of parameter doesn't match implemented member.
+dotnet_diagnostic.CS8617.severity = error
+# CS8619: Nullability of reference types in value doesn't match target type.
+dotnet_diagnostic.CS8619.severity = error
+#CS8620: Argument cannot be used for parameter due to differences in the nullability of reference types.
+dotnet_diagnostic.CS8620.severity = error
+#CS8621: Nullability of reference types in return type doesn't match the target delegate.
+dotnet_diagnostic.CS8621.severity = error
+#CS8622: Nullability of reference types in type of parameter doesn't match the target delegate.
+dotnet_diagnostic.CS8622.severity = error
+#CS8624: Argument cannot be used as an output for parameter due to differences in the nullability of reference types.
+dotnet_diagnostic.CS8624.severity = error
+#CS8625: Cannot convert null literal to non-nullable reference type.
+dotnet_diagnostic.CS8625.severity = error
+#CS8626: The 'as' operator may produce a null value for a type parameter.
+dotnet_diagnostic.CS8626.severity = error
+#CS8629: Nullable value type may be null.
+dotnet_diagnostic.CS8629.severity = error
+#CS8631: The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match constraint type.
+dotnet_diagnostic.CS8631.severity = error
+#CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+dotnet_diagnostic.CS8632.severity = error
+#CS8633: Nullability in constraints for type parameter doesn't match the constraints for type parameter in implicitly implemented interface method.
+dotnet_diagnostic.CS8633.severity = error
+#CS8634: The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'class' constraint.
+dotnet_diagnostic.CS8634.severity = error
+#CS8638: Conditional access may produce a null value for a type parameter.
+dotnet_diagnostic.CS8638.severity = error
+#CS8643: Nullability of reference types in explicit interface specifier doesn't match interface implemented by the type.
+dotnet_diagnostic.CS8643.severity = error
+#CS8644: Type does not implement interface member. Nullability of reference types in interface implemented by the base type doesn't match.
+dotnet_diagnostic.CS8644.severity = error
+#CS8645: Interface is already listed in the interface list with different nullability of reference types.
+dotnet_diagnostic.CS8645.severity = error
+#CS8653: A default expression introduces a null value for a type parameter.
+dotnet_diagnostic.CS8653.severity = error
+#CS8654: A null literal introduces a null value for a type parameter.
+dotnet_diagnostic.CS8654.severity = error
+#CS8655: The switch expression does not handle some null inputs.
+dotnet_diagnostic.CS8655.severity = error
+#CS8667: Partial method declarations have inconsistent nullability in constraints for type parameter
+dotnet_diagnostic.CS8667.severity = error
+#CS8714: The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
+dotnet_diagnostic.CS8714.severity = error
+#CS8618: Non-nullable property is uninitialized. Consider declaring the property as nullable.
+dotnet_diagnostic.CS8618.severity = error

--- a/AoCHelperSolution.sln
+++ b/AoCHelperSolution.sln
@@ -5,6 +5,7 @@ VisualStudioVersion = 16.0.29318.209
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2222508E-D4AB-455E-9089-C177579ACE08}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		.github\workflows\ci.yml = .github\workflows\ci.yml
 		Directory.Build.props = Directory.Build.props
 		.github\workflows\release.yml = .github\workflows\release.yml

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Creating your Advent of Code repository from [AdventOfCode.Template](https://git
   - Name them `DayXX` or `Day_XX` and make them inherit `BaseDay`.
   - Name them `ProblemXX` or `Problem_XX`and make them inherit `BaseProblem`.
 - **Put your input files under `Inputs/` directory** and follow `XX.txt` naming convention for day `XX`. Make sure to copy those files to your output folder.
-- Choose your **solving strategy** in your `Main()` method:
+- Choose your **solving strategy** in your `Main()` method, adjusting it with your custom `SolverConfiguration` if needed:
   - `Solver.SolveAll();`
   - `Solver.SolveLast();`
-  - `Solver.SolveLast(clearConsole: false);`
+  - `Solver.SolveLast(new SolverConfiguration { ClearConsole = false });`
   - `Solver.Solve<Day_05>();`
-  - `Solver.Solve(5, 6);`
-  - `Solver.Solve(typeof(Day_05), typeof(Day_06));`
+  - `Solver.Solve(new List<uint>{ 5, 6 });`
+  - `Solver.Solve(new List<Type> { typeof(Day_05), typeof(Day_06) });`
 
 ## Advanced usage
 
@@ -58,7 +58,7 @@ You can also:
   - Override `CalculateIndex()` to follow a different `XX` or `_XX` convention in your class names.
   - Override `InputFilePath` to follow a different naming convention in your input files. Check the [current implementation](https://github.com/eduherminio/AoCHelper/blob/master/src/AoCHelper/BaseProblem.cs) to understand how to reuse all the other properties and methods.
 - _[Not recommended]_ Override `InputFilePath` in any specific problem class to point to a concrete file. This will make the values of `ClassPrefix`, `InputFileDirPath` and `InputFileExtension` and the implementation of `CalculateIndex()` irrelevant (see the [current implementation](https://github.com/eduherminio/AoCHelper/blob/master/src/AoCHelper/BaseProblem.cs)).
-- Override `Solver.ElapsedTimeFormatSpecifier` to provide custom [numeric format strings](https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings) for the elapsed milliseconds.
+- ~~Override `Solver.ElapsedTimeFormatSpecifier`~~ Configure `SolverConfiguration.ElapsedTimeFormatSpecifier` to provide custom [numeric format strings](https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings) for the elapsed milliseconds.
 
 ## Usage examples
 

--- a/src/AoCHelper/Solver.cs
+++ b/src/AoCHelper/Solver.cs
@@ -149,7 +149,7 @@ namespace AoCHelper
                 }
             }
 
-            RenderAggregatedResultsGrid(totalElapsedTime);
+            RenderOverallResultsPanel(totalElapsedTime);
         }
 
         #endregion
@@ -286,7 +286,7 @@ namespace AoCHelper
             }
         }
 
-        private static void RenderAggregatedResultsGrid(List<(double part1, double part2)> totalElapsedTime)
+        private static void RenderOverallResultsPanel(List<(double part1, double part2)> totalElapsedTime)
         {
             var totalPart1 = totalElapsedTime.Select(t => t.part1).Sum();
             var totalPart2 = totalElapsedTime.Select(t => t.part2).Sum();
@@ -300,7 +300,7 @@ namespace AoCHelper
                 .AddRow("Total parts 1", FormatTime(totalPart1, useColor: false))
                 .AddRow("Total parts 2", FormatTime(totalPart2, useColor: false))
                 .AddRow()
-                .AddRow("Mean  (full day)", FormatTime(total / totalElapsedTime.Count))
+                .AddRow("Mean  (per day)", FormatTime(total / totalElapsedTime.Count))
                 .AddRow("Mean  parts 1", FormatTime(totalElapsedTime.Select(t => t.part1).Average()))
                 .AddRow("Mean  parts 2", FormatTime(totalElapsedTime.Select(t => t.part2).Average()));
 

--- a/src/AoCHelper/Solver.cs
+++ b/src/AoCHelper/Solver.cs
@@ -16,51 +16,6 @@ namespace AoCHelper
 
         private static readonly bool IsInteractiveEnvironment = Environment.UserInteractive && !Console.IsOutputRedirected;
 
-        private static Table GetTable() => new Table()
-                    .AddColumns("[bold white]Day[/]", "[bold white]Part[/]", "[bold white]Solution[/]", "[bold white]Elapsed time[/]")
-                    .RoundedBorder()
-                    .BorderColor(Color.Grey);
-
-        #region Obsolete methods
-
-        /// <summary>
-        /// This method is obsolete. Use <see cref="Solve{TProblem}(SolverConfiguration?)"/> instead.
-        /// </summary>
-        /// <typeparam name="TProblem"></typeparam>
-        /// <param name="clearConsole"></param>
-        [Obsolete("This method is obsolete. Use Solve<TProblem>(SolverConfiguration?) instead")]
-        public static void Solve<TProblem>(bool clearConsole = true)
-             where TProblem : BaseProblem, new()
-        {
-            Solve<TProblem>(new SolverConfiguration { ClearConsole = clearConsole });
-        }
-
-        /// <summary>
-        /// This method is obsolete. Use <see cref="SolveLast(SolverConfiguration?)"/> instead.
-        /// </summary>
-        /// <param name="clearConsole"></param>
-        [Obsolete("This method is obsolete. Use SolveLast(SolverConfiguration?) instead")]
-        public static void SolveLast(bool clearConsole = true)
-        {
-            SolveLast(new SolverConfiguration { ClearConsole = clearConsole });
-        }
-
-        /// <summary>
-        /// This method is obsolete. Use <see cref="Solve(SolverConfiguration?, Type[])"/> instead or <see cref="Solve(IEnumerable{Type}, SolverConfiguration?)"/> instead.
-        /// </summary>
-        /// <param name="problems"></param>
-        [Obsolete("This method is obsolete. Use Solve(SolverConfiguration?, params Type[]) or Solve(IEnumerable<Type>, SolverConfiguration?) instead")]
-        public static void Solve(params Type[] problems) => Solve(null, problems);
-
-        /// <summary>
-        /// This method is obsolete. Use <see cref="Solve(SolverConfiguration?, uint[])"/> or <see cref="Solve(IEnumerable{uint}, SolverConfiguration?)"/> instead.
-        /// </summary>
-        /// <param name="problemNumbers"></param>
-        [Obsolete("This method is obsolete. Use Solve(SolverConfiguration?, params uint[]) or Solve(IEnumerable<uint>, SolverConfiguration?) instead")]
-        public static void Solve(params uint[] problemNumbers) => Solve(null, problemNumbers);
-
-        #endregion
-
         #region Public methods
 
         /// <summary>
@@ -168,6 +123,43 @@ namespace AoCHelper
 
         #endregion
 
+        #region Obsolete methods
+
+        /// <summary>
+        /// This method is obsolete. Use <see cref="Solve{TProblem}(SolverConfiguration?)"/> instead.
+        /// </summary>
+        /// <typeparam name="TProblem"></typeparam>
+        /// <param name="clearConsole"></param>
+        [Obsolete("This method is obsolete. Use Solve<TProblem>(SolverConfiguration?) instead")]
+        public static void Solve<TProblem>(bool clearConsole)
+             where TProblem : BaseProblem, new()
+        {
+            Solve<TProblem>(new SolverConfiguration { ClearConsole = clearConsole });
+        }
+
+        /// <summary>
+        /// This method is obsolete. Use <see cref="SolveLast(SolverConfiguration?)"/> instead.
+        /// </summary>
+        /// <param name="clearConsole"></param>
+        [Obsolete("This method is obsolete. Use SolveLast(SolverConfiguration?) instead")]
+        public static void SolveLast(bool clearConsole) => SolveLast(new SolverConfiguration { ClearConsole = clearConsole });
+
+        /// <summary>
+        /// This method is obsolete. Use <see cref="Solve(SolverConfiguration?, Type[])"/> instead or <see cref="Solve(IEnumerable{Type}, SolverConfiguration?)"/> instead.
+        /// </summary>
+        /// <param name="problems"></param>
+        [Obsolete("This method is obsolete. Use Solve(SolverConfiguration?, params Type[]) or Solve(IEnumerable<Type>, SolverConfiguration?) instead")]
+        public static void Solve(params Type[] problems) => Solve(null, problems);
+
+        /// <summary>
+        /// This method is obsolete. Use <see cref="Solve(SolverConfiguration?, uint[])"/> or <see cref="Solve(IEnumerable{uint}, SolverConfiguration?)"/> instead.
+        /// </summary>
+        /// <param name="problemNumbers"></param>
+        [Obsolete("This method is obsolete. Use Solve(SolverConfiguration?, params uint[]) or Solve(IEnumerable<uint>, SolverConfiguration?) instead")]
+        public static void Solve(params uint[] problemNumbers) => Solve(null, problemNumbers);
+
+        #endregion
+
         /// <summary>
         /// Loads all <see cref="BaseProblem"/> in the given assembly
         /// </summary>
@@ -177,6 +169,14 @@ namespace AoCHelper
         {
             return assembly.GetTypes()
                 .Where(type => typeof(BaseProblem).IsAssignableFrom(type) && !type.IsInterface && !type.IsAbstract);
+        }
+
+        private static Table GetTable()
+        {
+            return new Table()
+                .AddColumns("[bold white]Day[/]", "[bold white]Part[/]", "[bold white]Solution[/]", "[bold white]Elapsed time[/]")
+                .RoundedBorder()
+                .BorderColor(Color.Grey);
         }
 
         private static (double part1, double part2) SolveProblem(BaseProblem problem, Table table, SolverConfiguration? configuration)

--- a/src/AoCHelper/Solver.cs
+++ b/src/AoCHelper/Solver.cs
@@ -18,6 +18,32 @@ namespace AoCHelper
                     .RoundedBorder()
                     .BorderColor(Color.Grey);
 
+        #region Obsolete methods
+
+        /// <summary>
+        /// This method is obsolete. Use <see cref="Solve{TProblem}(SolverConfiguration?)"/> instead
+        /// </summary>
+        /// <typeparam name="TProblem"></typeparam>
+        /// <param name="clearConsole"></param>
+        [Obsolete("This method is obsolete. Use Solve<TProblem>(SolverConfiguration?) instead")]
+        public static void Solve<TProblem>(bool clearConsole = true)
+             where TProblem : BaseProblem, new()
+        {
+            Solve<TProblem>(new SolverConfiguration { ClearConsole = clearConsole });
+        }
+
+        /// <summary>
+        /// This method is obsolete. Use <see cref="SolveLast(SolverConfiguration?)"/> instead
+        /// </summary>
+        /// <param name="clearConsole"></param>
+        [Obsolete("This method is obsolete. Use SolveLast(SolverConfiguration?) instead")]
+        public static void SolveLast(bool clearConsole = true)
+        {
+            SolveLast(new SolverConfiguration { ClearConsole = clearConsole });
+        }
+
+        #endregion
+
         #region Public methods
 
         /// <summary>

--- a/src/AoCHelper/Solver.cs
+++ b/src/AoCHelper/Solver.cs
@@ -24,7 +24,7 @@ namespace AoCHelper
         #region Obsolete methods
 
         /// <summary>
-        /// This method is obsolete. Use <see cref="Solve{TProblem}(SolverConfiguration?)"/> instead
+        /// This method is obsolete. Use <see cref="Solve{TProblem}(SolverConfiguration?)"/> instead.
         /// </summary>
         /// <typeparam name="TProblem"></typeparam>
         /// <param name="clearConsole"></param>
@@ -36,7 +36,7 @@ namespace AoCHelper
         }
 
         /// <summary>
-        /// This method is obsolete. Use <see cref="SolveLast(SolverConfiguration?)"/> instead
+        /// This method is obsolete. Use <see cref="SolveLast(SolverConfiguration?)"/> instead.
         /// </summary>
         /// <param name="clearConsole"></param>
         [Obsolete("This method is obsolete. Use SolveLast(SolverConfiguration?) instead")]
@@ -44,6 +44,20 @@ namespace AoCHelper
         {
             SolveLast(new SolverConfiguration { ClearConsole = clearConsole });
         }
+
+        /// <summary>
+        /// This method is obsolete. Use <see cref="Solve(SolverConfiguration?, Type[])"/> instead or <see cref="Solve(IEnumerable{Type}, SolverConfiguration?)"/> instead.
+        /// </summary>
+        /// <param name="problems"></param>
+        [Obsolete("This method is obsolete. Use Solve(SolverConfiguration?, params Type[]) or Solve(IEnumerable<Type>, SolverConfiguration?) instead")]
+        public static void Solve(params Type[] problems) => Solve(null, problems);
+
+        /// <summary>
+        /// This method is obsolete. Use <see cref="Solve(SolverConfiguration?, uint[])"/> or <see cref="Solve(IEnumerable{uint}, SolverConfiguration?)"/> instead.
+        /// </summary>
+        /// <param name="problemNumbers"></param>
+        [Obsolete("This method is obsolete. Use Solve(SolverConfiguration?, params uint[]) or Solve(IEnumerable<uint>, SolverConfiguration?) instead")]
+        public static void Solve(params uint[] problemNumbers) => Solve(null, problemNumbers);
 
         #endregion
 
@@ -187,8 +201,8 @@ namespace AoCHelper
         private static (string solution, double elapsedTime) SolvePart(bool isPart1, BaseProblem problem)
         {
             Stopwatch stopwatch = new Stopwatch();
-
             var solution = string.Empty;
+
             try
             {
                 Func<string> solve = isPart1

--- a/src/AoCHelper/Solver.cs
+++ b/src/AoCHelper/Solver.cs
@@ -25,28 +25,30 @@ namespace AoCHelper
         /// It also prints the elapsed time in <see cref="BaseProblem.Solve_1"/> and <see cref="BaseProblem.Solve_2"/> methods.
         /// </summary>
         /// <typeparam name="TProblem"></typeparam>
-        /// <param name="clearConsole"></param>
-        public static void Solve<TProblem>(bool clearConsole = true)
+        /// <param name="configuration"></param>
+        public static void Solve<TProblem>(SolverConfiguration? configuration = null)
             where TProblem : BaseProblem, new()
         {
             TProblem problem = new TProblem();
 
-            Solve(problem, GetTable(), clearConsole);
+            Solve(problem, GetTable(), configuration);
         }
 
         /// <summary>
         /// Solves those problems whose <see cref="BaseProblem.CalculateIndex"/> method matches one of the provided numbers.
         /// 0 can be used for those problems whose <see cref="BaseProblem.CalculateIndex"/> returns the default value due to not being able to deduct the index.
         /// </summary>
+        /// <param name="configuration"></param>
         /// <param name="problemNumbers"></param>
-        public static void Solve(params uint[] problemNumbers) => Solve(problemNumbers.AsEnumerable());
+        public static void Solve(SolverConfiguration? configuration = null, params uint[] problemNumbers) => Solve(problemNumbers.AsEnumerable(), configuration);
 
         /// <summary>
         /// Solves those problems whose <see cref="BaseProblem.CalculateIndex"/> method matches one of the provided numbers.
         /// 0 can be used for those problems whose <see cref="BaseProblem.CalculateIndex"/> returns the default value due to not being able to deduct the index.
         /// </summary>
         /// <param name="problemNumbers"></param>
-        public static void Solve(IEnumerable<uint> problemNumbers)
+        /// <param name="configuration"></param>
+        public static void Solve(IEnumerable<uint> problemNumbers, SolverConfiguration? configuration = null)
         {
             var table = GetTable();
 
@@ -54,7 +56,7 @@ namespace AoCHelper
             {
                 if (Activator.CreateInstance(problemType) is BaseProblem problem && problemNumbers.Contains(problem.CalculateIndex()))
                 {
-                    Solve(problem, table, clearConsole: true);
+                    Solve(problem, table, configuration);
                 }
             }
         }
@@ -63,13 +65,13 @@ namespace AoCHelper
         /// Solves last problem.
         /// It also prints the elapsed time in <see cref="BaseProblem.Solve_1"/> and <see cref="BaseProblem.Solve_2"/> methods.
         /// </summary>
-        /// <param name="clearConsole"></param>
-        public static void SolveLast(bool clearConsole = true)
+        /// <param name="configuration"></param>
+        public static void SolveLast(SolverConfiguration? configuration = null)
         {
             var lastProblem = LoadAllProblems(Assembly.GetEntryAssembly()!).LastOrDefault();
             if (lastProblem is not null && Activator.CreateInstance(lastProblem) is BaseProblem problem)
             {
-                Solve(problem, GetTable(), clearConsole);
+                Solve(problem, GetTable(), configuration);
             }
         }
 
@@ -77,13 +79,13 @@ namespace AoCHelper
         /// Solves the provided problems.
         /// It also prints the elapsed time in <see cref="BaseProblem.Solve_1"/> and <see cref="BaseProblem.Solve_2"/> methods.
         /// </summary>
-        public static void Solve(params Type[] problems) => Solve(problems.AsEnumerable());
+        public static void Solve(SolverConfiguration? configuration = null, params Type[] problems) => Solve(problems.AsEnumerable(), configuration);
 
         /// <summary>
         /// Solves the provided problems.
         /// It also prints the elapsed time in <see cref="BaseProblem.Solve_1"/> and <see cref="BaseProblem.Solve_2"/> methods.
         /// </summary>
-        public static void Solve(IEnumerable<Type> problems)
+        public static void Solve(IEnumerable<Type> problems, SolverConfiguration? configuration = null)
         {
             var table = GetTable();
 
@@ -91,7 +93,7 @@ namespace AoCHelper
             {
                 if (problems.Contains(problemType) && Activator.CreateInstance(problemType) is BaseProblem problem)
                 {
-                    Solve(problem, table, clearConsole: true);
+                    Solve(problem, table, configuration);
                 }
             }
         }
@@ -100,7 +102,8 @@ namespace AoCHelper
         /// Solves all problems in the assembly.
         /// It also prints the elapsed time in <see cref="BaseProblem.Solve_1"/> and <see cref="BaseProblem.Solve_2"/> methods.
         /// </summary>
-        public static void SolveAll()
+        /// <param name="configuration"></param>
+        public static void SolveAll(SolverConfiguration? configuration = null)
         {
             var totalElapsedTime = new List<(double part1, double part2)>();
             var table = GetTable();
@@ -109,7 +112,7 @@ namespace AoCHelper
             {
                 if (Activator.CreateInstance(problemType) is BaseProblem problem)
                 {
-                    totalElapsedTime.Add(Solve(problem, table, clearConsole: true));
+                    totalElapsedTime.Add(Solve(problem, table, configuration));
                 }
             }
 
@@ -128,18 +131,19 @@ namespace AoCHelper
                 .Where(type => typeof(BaseProblem).IsAssignableFrom(type) && !type.IsInterface && !type.IsAbstract);
         }
 
-        private static (double part1, double part2) Solve(BaseProblem problem, Table table, bool clearConsole)
+        private static (double part1, double part2) Solve(BaseProblem problem, Table table, SolverConfiguration? configuration)
         {
+            configuration ??= new SolverConfiguration();
             var problemIndex = problem.CalculateIndex();
             var problemTitle = problemIndex != default
                 ? $"Day {problemIndex}"
                 : $"{problem.GetType().Name}";
 
             (string solution1, double elapsedMillisecondsPart1) = SolvePart(isPart1: true, problem);
-            RenderRow(table, problemTitle, 1, solution1, elapsedMillisecondsPart1, clearConsole);
+            RenderRow(table, problemTitle, 1, solution1, elapsedMillisecondsPart1, configuration.ClearConsole);
 
             (string solution2, double elapsedMillisecondsPart2) = SolvePart(isPart1: false, problem);
-            RenderRow(table, problemTitle, 2, solution2, elapsedMillisecondsPart2, clearConsole);
+            RenderRow(table, problemTitle, 2, solution2, elapsedMillisecondsPart2, configuration.ClearConsole);
 
             table.AddEmptyRow();
 

--- a/src/AoCHelper/Solver.cs
+++ b/src/AoCHelper/Solver.cs
@@ -9,11 +9,6 @@ namespace AoCHelper
 {
     public static class Solver
     {
-        /// <summary>
-        /// Numeric format strings, see https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings
-        /// </summary>
-        public static string? ElapsedTimeFormatSpecifier { get; set; } = null;
-
         private static readonly bool IsInteractiveEnvironment = Environment.UserInteractive && !Console.IsOutputRedirected;
 
         #region Public methods
@@ -27,36 +22,10 @@ namespace AoCHelper
         public static void Solve<TProblem>(SolverConfiguration? configuration = null)
             where TProblem : BaseProblem, new()
         {
+            configuration ??= new();
             TProblem problem = new TProblem();
 
             SolveProblem(problem, GetTable(), configuration);
-        }
-
-        /// <summary>
-        /// Solves those problems whose <see cref="BaseProblem.CalculateIndex"/> method matches one of the provided numbers.
-        /// 0 can be used for those problems whose <see cref="BaseProblem.CalculateIndex"/> returns the default value due to not being able to deduct the index.
-        /// </summary>
-        /// <param name="configuration"></param>
-        /// <param name="problemNumbers"></param>
-        public static void Solve(SolverConfiguration? configuration = null, params uint[] problemNumbers) => Solve(problemNumbers.AsEnumerable(), configuration);
-
-        /// <summary>
-        /// Solves those problems whose <see cref="BaseProblem.CalculateIndex"/> method matches one of the provided numbers.
-        /// 0 can be used for those problems whose <see cref="BaseProblem.CalculateIndex"/> returns the default value due to not being able to deduct the index.
-        /// </summary>
-        /// <param name="problemNumbers"></param>
-        /// <param name="configuration"></param>
-        public static void Solve(IEnumerable<uint> problemNumbers, SolverConfiguration? configuration = null)
-        {
-            var table = GetTable();
-
-            foreach (Type problemType in LoadAllProblems(Assembly.GetEntryAssembly()!))
-            {
-                if (Activator.CreateInstance(problemType) is BaseProblem problem && problemNumbers.Contains(problem.CalculateIndex()))
-                {
-                    SolveProblem(problem, table, configuration);
-                }
-            }
         }
 
         /// <summary>
@@ -66,6 +35,8 @@ namespace AoCHelper
         /// <param name="configuration"></param>
         public static void SolveLast(SolverConfiguration? configuration = null)
         {
+            configuration ??= new();
+
             var lastProblem = LoadAllProblems(Assembly.GetEntryAssembly()!).LastOrDefault();
             if (lastProblem is not null && Activator.CreateInstance(lastProblem) is BaseProblem problem)
             {
@@ -74,12 +45,46 @@ namespace AoCHelper
         }
 
         /// <summary>
+        /// Solves those problems whose <see cref="BaseProblem.CalculateIndex"/> method matches one of the provided numbers.
+        /// 0 can be used for those problems whose <see cref="BaseProblem.CalculateIndex"/> returns the default value due to not being able to deduct the index.
+        /// </summary>
+        /// <param name="configuration"></param>
+        /// <param name="problemNumbers"></param>
+        public static void Solve(SolverConfiguration? configuration = null, params uint[] problemNumbers)
+            => Solve(problemNumbers.AsEnumerable(), configuration);
+
+        /// <summary>
         /// Solves the provided problems.
         /// It also prints the elapsed time in <see cref="BaseProblem.Solve_1"/> and <see cref="BaseProblem.Solve_2"/> methods.
         /// </summary>
         /// <param name="configuration"></param>
         /// <param name="problems"></param>
-        public static void Solve(SolverConfiguration? configuration = null, params Type[] problems) => Solve(problems.AsEnumerable(), configuration);
+        public static void Solve(SolverConfiguration? configuration = null, params Type[] problems)
+            => Solve(problems.AsEnumerable(), configuration);
+
+        /// <summary>
+        /// Solves those problems whose <see cref="BaseProblem.CalculateIndex"/> method matches one of the provided numbers.
+        /// 0 can be used for those problems whose <see cref="BaseProblem.CalculateIndex"/> returns the default value due to not being able to deduct the index.
+        /// </summary>
+        /// <param name="problemNumbers"></param>
+        /// <param name="configuration"></param>
+        public static void Solve(IEnumerable<uint> problemNumbers, SolverConfiguration? configuration = null)
+        {
+            configuration ??= new() { ShowOverallResults = problemNumbers.Count() > 1 };
+
+            var totalElapsedTime = new List<(double part1, double part2)>();
+            var table = GetTable();
+
+            foreach (Type problemType in LoadAllProblems(Assembly.GetEntryAssembly()!))
+            {
+                if (Activator.CreateInstance(problemType) is BaseProblem problem && problemNumbers.Contains(problem.CalculateIndex()))
+                {
+                    totalElapsedTime.Add(SolveProblem(problem, table, configuration));
+                }
+            }
+
+            RenderOverallResultsPanel(totalElapsedTime, configuration);
+        }
 
         /// <summary>
         /// Solves the provided problems.
@@ -89,15 +94,20 @@ namespace AoCHelper
         /// <param name="configuration"></param>
         public static void Solve(IEnumerable<Type> problems, SolverConfiguration? configuration = null)
         {
+            configuration ??= new() { ShowOverallResults = true };
+
+            var totalElapsedTime = new List<(double part1, double part2)>();
             var table = GetTable();
 
             foreach (Type problemType in LoadAllProblems(Assembly.GetEntryAssembly()!))
             {
                 if (problems.Contains(problemType) && Activator.CreateInstance(problemType) is BaseProblem problem)
                 {
-                    SolveProblem(problem, table, configuration);
+                    totalElapsedTime.Add(SolveProblem(problem, table, configuration));
                 }
             }
+
+            RenderOverallResultsPanel(totalElapsedTime, configuration);
         }
 
         /// <summary>
@@ -107,6 +117,8 @@ namespace AoCHelper
         /// <param name="configuration"></param>
         public static void SolveAll(SolverConfiguration? configuration = null)
         {
+            configuration ??= new() { ShowOverallResults = true };
+
             var totalElapsedTime = new List<(double part1, double part2)>();
             var table = GetTable();
 
@@ -118,12 +130,18 @@ namespace AoCHelper
                 }
             }
 
-            RenderOverallResultsPanel(totalElapsedTime);
+            RenderOverallResultsPanel(totalElapsedTime, configuration);
         }
 
         #endregion
 
-        #region Obsolete methods
+        #region Obsolete methods and properties
+
+        /// <summary>
+        /// This property is obsolete. Use <see cref="SolverConfiguration.ElapsedTimeFormatSpecifier"/> instead
+        /// </summary>
+        [Obsolete("This property is obsolete. Use SolverConfiguration.ElapsedTimeFormatSpecifier instead")]
+        public static string? ElapsedTimeFormatSpecifier { get; set; }
 
         /// <summary>
         /// This method is obsolete. Use <see cref="Solve{TProblem}(SolverConfiguration?)"/> instead.
@@ -179,19 +197,18 @@ namespace AoCHelper
                 .BorderColor(Color.Grey);
         }
 
-        private static (double part1, double part2) SolveProblem(BaseProblem problem, Table table, SolverConfiguration? configuration)
+        private static (double part1, double part2) SolveProblem(BaseProblem problem, Table table, SolverConfiguration configuration)
         {
-            configuration ??= new SolverConfiguration();
             var problemIndex = problem.CalculateIndex();
             var problemTitle = problemIndex != default
                 ? $"Day {problemIndex}"
                 : $"{problem.GetType().Name}";
 
             (string solution1, double elapsedMillisecondsPart1) = SolvePart(isPart1: true, problem);
-            RenderRow(table, problemTitle, 1, solution1, elapsedMillisecondsPart1, configuration.ClearConsole);
+            RenderRow(table, problemTitle, 1, solution1, elapsedMillisecondsPart1, configuration);
 
             (string solution2, double elapsedMillisecondsPart2) = SolvePart(isPart1: false, problem);
-            RenderRow(table, problemTitle, 2, solution2, elapsedMillisecondsPart2, configuration.ClearConsole);
+            RenderRow(table, problemTitle, 2, solution2, elapsedMillisecondsPart2, configuration);
 
             table.AddEmptyRow();
 
@@ -240,15 +257,15 @@ namespace AoCHelper
             return 1000 * stopwatch.ElapsedTicks / (double)Stopwatch.Frequency;
         }
 
-        private static void RenderRow(Table table, string problemTitle, int part, string solution, double elapsedMilliseconds, bool clearConsole)
+        private static void RenderRow(Table table, string problemTitle, int part, string solution, double elapsedMilliseconds, SolverConfiguration configuration)
         {
-            var formattedTime = FormatTime(elapsedMilliseconds);
+            var formattedTime = FormatTime(elapsedMilliseconds, configuration);
 
             table.AddRow(problemTitle, $"Part {part}", solution, formattedTime);
 
             if (IsInteractiveEnvironment)
             {
-                if (clearConsole)
+                if (configuration?.ClearConsole == true)
                 {
                     Console.Clear();
                 }
@@ -261,9 +278,13 @@ namespace AoCHelper
             AnsiConsole.Render(table);
         }
 
-        private static string FormatTime(double elapsedMilliseconds, bool useColor = true)
+        private static string FormatTime(double elapsedMilliseconds, SolverConfiguration configuration, bool useColor = true)
         {
-            var message = ElapsedTimeFormatSpecifier is null
+#pragma warning disable CS0618 // Type or member is obsolete - Needed to keep compatibility
+            var customFormatSpecifier = configuration?.ElapsedTimeFormatSpecifier ?? ElapsedTimeFormatSpecifier;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            var message = customFormatSpecifier is null
                 ? elapsedMilliseconds switch
                 {
                     < 1 => $"{elapsedMilliseconds:F} ms",
@@ -273,10 +294,10 @@ namespace AoCHelper
                 }
                 : elapsedMilliseconds switch
                 {
-                    < 1 => $"{elapsedMilliseconds.ToString(ElapsedTimeFormatSpecifier)} ms",
-                    < 1_000 => $"{elapsedMilliseconds.ToString(ElapsedTimeFormatSpecifier)} ms",
-                    < 60_000 => $"{(0.001 * elapsedMilliseconds).ToString(ElapsedTimeFormatSpecifier)} s",
-                    _ => $"{elapsedMilliseconds / 60_000} min {(0.001 * (elapsedMilliseconds % 60_000)).ToString(ElapsedTimeFormatSpecifier)} s",
+                    < 1 => $"{elapsedMilliseconds.ToString(customFormatSpecifier)} ms",
+                    < 1_000 => $"{elapsedMilliseconds.ToString(customFormatSpecifier)} ms",
+                    < 60_000 => $"{(0.001 * elapsedMilliseconds).ToString(customFormatSpecifier)} s",
+                    _ => $"{elapsedMilliseconds / 60_000} min {(0.001 * (elapsedMilliseconds % 60_000)).ToString(customFormatSpecifier)} s",
                 };
 
             if (useColor)
@@ -300,8 +321,13 @@ namespace AoCHelper
             }
         }
 
-        private static void RenderOverallResultsPanel(List<(double part1, double part2)> totalElapsedTime)
+        private static void RenderOverallResultsPanel(List<(double part1, double part2)> totalElapsedTime, SolverConfiguration configuration)
         {
+            if (configuration?.ShowOverallResults != true)
+            {
+                return;
+            }
+
             var totalPart1 = totalElapsedTime.Select(t => t.part1).Sum();
             var totalPart2 = totalElapsedTime.Select(t => t.part2).Sum();
             var total = totalPart1 + totalPart2;
@@ -310,13 +336,13 @@ namespace AoCHelper
                 .AddColumn(new GridColumn().NoWrap().PadRight(4))
                 .AddColumn()
                 .AddRow()
-                .AddRow($"Total ({totalElapsedTime.Count} days)", FormatTime(total, useColor: false))
-                .AddRow("Total parts 1", FormatTime(totalPart1, useColor: false))
-                .AddRow("Total parts 2", FormatTime(totalPart2, useColor: false))
+                .AddRow($"Total ({totalElapsedTime.Count} days)", FormatTime(total, configuration, useColor: false))
+                .AddRow("Total parts 1", FormatTime(totalPart1, configuration, useColor: false))
+                .AddRow("Total parts 2", FormatTime(totalPart2, configuration, useColor: false))
                 .AddRow()
-                .AddRow("Mean  (per day)", FormatTime(total / totalElapsedTime.Count))
-                .AddRow("Mean  parts 1", FormatTime(totalElapsedTime.Select(t => t.part1).Average()))
-                .AddRow("Mean  parts 2", FormatTime(totalElapsedTime.Select(t => t.part2).Average()));
+                .AddRow("Mean  (per day)", FormatTime(total / totalElapsedTime.Count, configuration))
+                .AddRow("Mean  parts 1", FormatTime(totalElapsedTime.Select(t => t.part1).Average(), configuration))
+                .AddRow("Mean  parts 2", FormatTime(totalElapsedTime.Select(t => t.part2).Average(), configuration));
 
             AnsiConsole.Render(
                     new Panel(grid)

--- a/src/AoCHelper/Solver.cs
+++ b/src/AoCHelper/Solver.cs
@@ -70,7 +70,7 @@ namespace AoCHelper
         /// <param name="configuration"></param>
         public static void Solve(IEnumerable<uint> problemNumbers, SolverConfiguration? configuration = null)
         {
-            configuration ??= new() { ShowOverallResults = problemNumbers.Count() > 1 };
+            configuration ??= new();
 
             var totalElapsedTime = new List<(double part1, double part2)>();
             var table = GetTable();
@@ -94,7 +94,7 @@ namespace AoCHelper
         /// <param name="configuration"></param>
         public static void Solve(IEnumerable<Type> problems, SolverConfiguration? configuration = null)
         {
-            configuration ??= new() { ShowOverallResults = true };
+            configuration ??= new();
 
             var totalElapsedTime = new List<(double part1, double part2)>();
             var table = GetTable();
@@ -117,7 +117,7 @@ namespace AoCHelper
         /// <param name="configuration"></param>
         public static void SolveAll(SolverConfiguration? configuration = null)
         {
-            configuration ??= new() { ShowOverallResults = true };
+            configuration ??= new();
 
             var totalElapsedTime = new List<(double part1, double part2)>();
             var table = GetTable();
@@ -323,7 +323,7 @@ namespace AoCHelper
 
         private static void RenderOverallResultsPanel(List<(double part1, double part2)> totalElapsedTime, SolverConfiguration configuration)
         {
-            if (configuration?.ShowOverallResults != true)
+            if (configuration?.ShowOverallResults != true || totalElapsedTime.Count <= 1)
             {
                 return;
             }

--- a/src/AoCHelper/Solver.cs
+++ b/src/AoCHelper/Solver.cs
@@ -102,15 +102,18 @@ namespace AoCHelper
         /// </summary>
         public static void SolveAll()
         {
+            var totalElapsedTime = new List<(double part1, double part2)>();
             var table = GetTable();
 
             foreach (Type problemType in LoadAllProblems(Assembly.GetEntryAssembly()!))
             {
                 if (Activator.CreateInstance(problemType) is BaseProblem problem)
                 {
-                    Solve(problem, table, clearConsole: true);
+                    totalElapsedTime.Add(Solve(problem, table, clearConsole: true));
                 }
             }
+
+            RenderAggregatedResultsGrid(totalElapsedTime);
         }
 
         #endregion
@@ -125,77 +128,88 @@ namespace AoCHelper
                 .Where(type => typeof(BaseProblem).IsAssignableFrom(type) && !type.IsInterface && !type.IsAbstract);
         }
 
-        private static void Solve(BaseProblem problem, Table table, bool clearConsole)
+        private static (double part1, double part2) Solve(BaseProblem problem, Table table, bool clearConsole)
         {
             var problemIndex = problem.CalculateIndex();
             var problemTitle = problemIndex != default
                 ? $"Day {problemIndex}"
                 : $"{problem.GetType().Name}";
 
-            Stopwatch stopwatch = null!;
+            (string solution1, double elapsedMillisecondsPart1) = SolvePart(isPart1: true, problem);
+            RenderRow(table, problemTitle, 1, solution1, elapsedMillisecondsPart1, clearConsole);
 
-            var solution1 = string.Empty;
-            try
-            {
-                stopwatch = Stopwatch.StartNew();
-                solution1 = problem.Solve_1();
-            }
-            catch (NotImplementedException)
-            {
-                solution1 = "[[Not implemented]]";
-            }
-            catch (Exception e)
-            {
-                solution1 = e.Message + Environment.NewLine + e.StackTrace;
-            }
-            finally
-            {
-                stopwatch.Stop();
-            }
-
-            RenderRow(table, problemTitle, 1, solution1, stopwatch!, clearConsole);
-
-            var solution2 = string.Empty;
-            try
-            {
-                stopwatch.Reset();
-                stopwatch.Restart();
-                solution2 = problem.Solve_2();
-            }
-            catch (NotImplementedException)
-            {
-                solution2 = "[[Not implemented]]";
-            }
-            catch (Exception e)
-            {
-                solution2 = e.Message + Environment.NewLine + e.StackTrace;
-            }
-            finally
-            {
-                stopwatch.Stop();
-            }
-
-            RenderRow(table, problemTitle, 2, solution2, stopwatch, clearConsole);
+            (string solution2, double elapsedMillisecondsPart2) = SolvePart(isPart1: false, problem);
+            RenderRow(table, problemTitle, 2, solution2, elapsedMillisecondsPart2, clearConsole);
 
             table.AddEmptyRow();
+
+            return (elapsedMillisecondsPart1, elapsedMillisecondsPart2);
         }
 
-        private static void RenderRow(Table table, string problemTitle, int part, string solution, Stopwatch stopwatch, bool clearConsole)
+        private static (string solution, double elapsedTime) SolvePart(bool isPart1, BaseProblem problem)
         {
-            var elapsedMilliseconds = 1000 * stopwatch.ElapsedTicks / (double)Stopwatch.Frequency;
+            Stopwatch stopwatch = new Stopwatch();
 
-            var color = elapsedMilliseconds switch
+            var solution = string.Empty;
+            try
             {
-                < 1 => Color.Blue,
-                < 10 => Color.Green1,
-                < 100 => Color.Lime,
-                < 500 => Color.GreenYellow,
-                < 1_000 => Color.Yellow1,
-                < 10_000 => Color.OrangeRed1,
-                _ => Color.Red1
-            };
+                stopwatch.Restart();
+                solution = isPart1
+                    ? problem.Solve_1()
+                    : problem.Solve_2();
+            }
+            catch (NotImplementedException)
+            {
+                solution = "[[Not implemented]]";
+            }
+            catch (Exception e)
+            {
+                solution = e.Message + Environment.NewLine + e.StackTrace;
+            }
+            finally
+            {
+                stopwatch.Stop();
+            }
 
-            var elapsedTime = MillisecondsFormatSpecifier is null
+            var elapsedMilliseconds = CalculateElapsedMilliseconds(stopwatch);
+
+            return (solution, elapsedMilliseconds);
+        }
+
+        /// <summary>
+        /// http://geekswithblogs.net/BlackRabbitCoder/archive/2012/01/12/c.net-little-pitfalls-stopwatch-ticks-are-not-timespan-ticks.aspx
+        /// </summary>
+        /// <param name="stopwatch"></param>
+        /// <returns></returns>
+        private static double CalculateElapsedMilliseconds(Stopwatch stopwatch)
+        {
+            return 1000 * stopwatch.ElapsedTicks / (double)Stopwatch.Frequency;
+        }
+
+        private static void RenderRow(Table table, string problemTitle, int part, string solution, double elapsedMilliseconds, bool clearConsole)
+        {
+            var formattedTime = FormatTime(elapsedMilliseconds);
+
+            table.AddRow(problemTitle, $"Part {part}", solution, formattedTime);
+
+            if (IsInteractiveEnvironment)
+            {
+                if (clearConsole)
+                {
+                    Console.Clear();
+                }
+                else
+                {
+                    AnsiConsole.Console.Clear(true);
+                }
+            }
+
+            AnsiConsole.Render(table);
+        }
+
+        private static string FormatTime(double elapsedMilliseconds, bool useColor = true)
+        {
+            var message = MillisecondsFormatSpecifier is null
                 ? elapsedMilliseconds switch
                 {
                     < 1 => $"{elapsedMilliseconds:F} ms",
@@ -211,21 +225,48 @@ namespace AoCHelper
                     _ => $"{elapsedMilliseconds / 60_000} min {(0.001 * (elapsedMilliseconds % 60_000)).ToString(MillisecondsFormatSpecifier)} s",
                 };
 
-            table.AddRow(problemTitle, $"Part {part}", solution, $"[{color}]{elapsedTime}[/]");
-
-            if (IsInteractiveEnvironment)
+            if (useColor)
             {
-                if (clearConsole)
+                var color = elapsedMilliseconds switch
                 {
-                    Console.Clear();
-                }
-                else
-                {
-                    AnsiConsole.Console.Clear(true);
-                }
-            }
+                    < 1 => Color.Blue,
+                    < 10 => Color.Green1,
+                    < 100 => Color.Lime,
+                    < 500 => Color.GreenYellow,
+                    < 1_000 => Color.Yellow1,
+                    < 10_000 => Color.OrangeRed1,
+                    _ => Color.Red1
+                };
 
-            AnsiConsole.Render(table);
+                return $"[{color}]{message}[/]";
+            }
+            else
+            {
+                return message;
+            }
+        }
+
+        private static void RenderAggregatedResultsGrid(List<(double part1, double part2)> totalElapsedTime)
+        {
+            var totalPart1 = totalElapsedTime.Select(t => t.part1).Sum();
+            var totalPart2 = totalElapsedTime.Select(t => t.part2).Sum();
+            var total = totalPart1 + totalPart2;
+
+            var grid = new Grid()
+                .AddColumn(new GridColumn().NoWrap().PadRight(4))
+                .AddColumn()
+                .AddRow()
+                .AddRow($"Total ({totalElapsedTime.Count} days)", FormatTime(total, useColor: false))
+                .AddRow("Total parts 1", FormatTime(totalPart1, useColor: false))
+                .AddRow("Total parts 2", FormatTime(totalPart2, useColor: false))
+                .AddRow()
+                .AddRow("Mean  (full day)", FormatTime(total / totalElapsedTime.Count))
+                .AddRow("Mean  parts 1", FormatTime(totalElapsedTime.Select(t => t.part1).Average()))
+                .AddRow("Mean  parts 2", FormatTime(totalElapsedTime.Select(t => t.part2).Average()));
+
+            AnsiConsole.Render(
+                    new Panel(grid)
+                        .Header("[b] Overall results [/]", Justify.Center));
         }
     }
 }

--- a/src/AoCHelper/SolverConfiguration.cs
+++ b/src/AoCHelper/SolverConfiguration.cs
@@ -1,0 +1,12 @@
+﻿namespace AoCHelper
+{
+    public class SolverConfiguration
+    {
+        public bool ClearConsole { get; set; }
+
+        public SolverConfiguration()
+        {
+            ClearConsole = true;
+        }
+    }
+}

--- a/src/AoCHelper/SolverConfiguration.cs
+++ b/src/AoCHelper/SolverConfiguration.cs
@@ -23,6 +23,7 @@
         public SolverConfiguration()
         {
             ClearConsole = true;
+            ShowOverallResults = true;
         }
     }
 }

--- a/src/AoCHelper/SolverConfiguration.cs
+++ b/src/AoCHelper/SolverConfiguration.cs
@@ -8,6 +8,18 @@
         /// </summary>
         public bool ClearConsole { get; set; }
 
+        /// <summary>
+        /// Shows a panel at the end of the run with aggregated stats of the solved problems.
+        /// True by default when solving multiple problems, false otherwise.
+        /// </summary>
+        public bool ShowOverallResults { get; set; }
+
+        /// <summary>
+        /// Custom numeric format strings used when .
+        /// See https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings
+        /// </summary>
+        public string? ElapsedTimeFormatSpecifier { get; set; }
+
         public SolverConfiguration()
         {
             ClearConsole = true;

--- a/src/AoCHelper/SolverConfiguration.cs
+++ b/src/AoCHelper/SolverConfiguration.cs
@@ -2,6 +2,10 @@
 {
     public class SolverConfiguration
     {
+        /// <summary>
+        /// Clears previous runs information from the console.
+        /// True by default.
+        /// </summary>
         public bool ClearConsole { get; set; }
 
         public SolverConfiguration()

--- a/tests/AoCHelper.Test/AoCHelper.Test.csproj
+++ b/tests/AoCHelper.Test/AoCHelper.Test.csproj
@@ -22,6 +22,10 @@
     <ProjectReference Include="..\..\src\AoCHelper\AoCHelper.csproj" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <NoWarn>S2699</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Update="Inputs\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/tests/AoCHelper.Test/SolverTest.cs
+++ b/tests/AoCHelper.Test/SolverTest.cs
@@ -94,6 +94,13 @@ namespace AoCHelper.Test
 #pragma warning disable CS0618 // Tests should include assertions
 
         [Fact]
+        public void ObsoleteElapsedTimeFormatSpecifier()
+        {
+            Solver.ElapsedTimeFormatSpecifier = "F3";
+            Solver.SolveLast(false);
+        }
+
+        [Fact]
         public void ObsoleteSolve()
         {
             Solver.Solve<Problem66>(true);

--- a/tests/AoCHelper.Test/SolverTest.cs
+++ b/tests/AoCHelper.Test/SolverTest.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using Xunit;
@@ -32,30 +34,36 @@ namespace AoCHelper.Test
         public void Solve()
         {
             Solver.Solve<Problem66>();
+            Solver.Solve<Problem66>(new SolverConfiguration());
         }
 
         [Fact]
         public void SolveIntParams()
         {
-            Solver.Solve(1, 2);
+            Solver.Solve(null, 1, 2);
+            Solver.Solve(new SolverConfiguration(), 1, 2);
         }
 
         [Fact]
         public void SolveIntEnumerable()
         {
-            Solver.Solve(new uint[] { 1, 2 });
+            Solver.Solve(new List<uint> { 1, 2 });
+            Solver.Solve(new List<uint> { 1, 2 }, new SolverConfiguration());
         }
 
         [Fact]
         public void SolveTypeParams()
         {
-            Solver.Solve(typeof(Problem66));
+            SolverConfiguration? nullConfig = null;
+            Solver.Solve(nullConfig, typeof(Problem66));
+            Solver.Solve(new SolverConfiguration(), typeof(Problem66));
         }
 
         [Fact]
         public void SolveTypeEnumerable()
         {
-            Solver.Solve(new[] { typeof(Problem66) });
+            Solver.Solve(new List<Type> { typeof(Problem66) });
+            Solver.Solve(new List<Type> { typeof(Problem66) }, new SolverConfiguration());
         }
 
         /// <summary>
@@ -65,6 +73,7 @@ namespace AoCHelper.Test
         public void SolveLast()
         {
             Solver.SolveLast();
+            Solver.SolveLast(new SolverConfiguration());
         }
 
         [Fact]
@@ -80,5 +89,41 @@ namespace AoCHelper.Test
                 Assembly.GetExecutingAssembly()!.GetTypes().Count(type => typeof(BaseProblem).IsAssignableFrom(type) && !type.IsAbstract),
                 Solver.LoadAllProblems(Assembly.GetExecutingAssembly()).Count());
         }
+
+        #region Obsolete methods
+#pragma warning disable CS0618 // Tests should include assertions
+
+        [Fact]
+        public void ObsoleteSolve()
+        {
+            Solver.Solve<Problem66>(true);
+        }
+
+        [Fact]
+        public void ObsoleteSolveLast()
+        {
+            Solver.SolveLast(true);
+        }
+
+        [Fact]
+        public void ObsoleteSolveIntEnumerable()
+        {
+            Solver.Solve(new uint[] { 1, 2 });
+        }
+
+        [Fact]
+        public void ObsoleteSolveIntParams()
+        {
+            Solver.Solve(1, 2);
+        }
+
+        [Fact]
+        public void ObsoleteSolveTypeParams()
+        {
+            Solver.Solve(typeof(Problem66));
+        }
+
+#pragma warning restore CS0618
+        #endregion
     }
 }


### PR DESCRIPTION
* Add `SolverConfiguration` class as the way to modify the default `Solver` behavior, with the following public properties;
  * `bool ClearConsole`
  * `bool ShowOverallResults`
  * `string? ElapsedTimeFormatSpecifier`
* Add:
  * `Solver.Solve<TProblem>(SolverConfiguration)`
  * `Solver.SolveLast(SolverConfiguration)`
  * `Solver.Solve(IEnumerable<uint>, SolverConfiguration)`
  * `Solver.Solve(IEnumerable<Type>, SolverConfiguration)`
  * `Solver.Solve( SolverConfiguration, params uint[])`
  *  `Solver.Solve( SolverConfiguration, params Type[])`
* Deprecate (marked with `ObsoleteAttribute`, will be removed in the next major release):
  * `Solve<TProblem>(bool)`
  * `SolveLast(bool)`
  *  `Solver.Solve(params uint[])`
  * `Solver.Solve(params Type[])`
  * `Solver.ElapsedTimeFormatSpecifier `