### PR TITLE
Measure constructor time

### DIFF
--- a/src/AoCHelper/AoCHelper.csproj
+++ b/src/AoCHelper/AoCHelper.csproj
@@ -20,6 +20,10 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
+  <ItemGroup Label="https://github.com/dotnet/roslyn/issues/45510">
+    <Compile Remove="IsExternalInit.cs" Condition="'$(TargetFramework)' == 'net5.0'" />
+  </ItemGroup>
+
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>$(AssemblyName).Test</_Parameter1>

--- a/src/AoCHelper/AoCHelper.csproj
+++ b/src/AoCHelper/AoCHelper.csproj
@@ -7,7 +7,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Title>AoCHelper</Title>
     <PackageId>AoCHelper</PackageId>
-    <Version>0.14.0</Version>
+    <Version>0.15.0-alpha</Version>
     <PackageTags>AoC, AdventOfCode, Advent, Code</PackageTags>
     <Tags>$(PackageTags)</Tags>
     <Authors>Eduardo Cáceres</Authors>

--- a/src/AoCHelper/IsExternalInit.cs
+++ b/src/AoCHelper/IsExternalInit.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Source: https://github.com/dotnet/roslyn/issues/45510
+
+#if NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP2_0 || NETCOREAPP2_1 || NETCOREAPP2_2 || NETCOREAPP3_0 || NETCOREAPP3_1 || NET45 || NET451 || NET452 || NET6 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+
+using System.ComponentModel;
+
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit
+    {
+    }
+}
+
+#endif

--- a/src/AoCHelper/SolverConfiguration.cs
+++ b/src/AoCHelper/SolverConfiguration.cs
@@ -15,6 +15,17 @@
         public bool ShowOverallResults { get; set; }
 
         /// <summary>
+        /// Shows the time elapsed during the instantiation of a <see cref="BaseProblem"/>.
+        /// This normally reflects the elapsed time while parsing the input data.
+        /// </summary>
+        public bool ShowConstructorElapsedTime { get; set; }
+
+        /// <summary>
+        /// Shows total elapsed time per day. This includes constructor time + part 1 + part 2
+        /// </summary>
+        public bool ShowTotalElapsedTimePerDay { get; set; }
+
+        /// <summary>
         /// Custom numeric format strings used when .
         /// See https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings
         /// </summary>
@@ -24,6 +35,8 @@
         {
             ClearConsole = true;
             ShowOverallResults = true;
+            ShowConstructorElapsedTime = false;
+            ShowTotalElapsedTimePerDay = false;
         }
     }
 }


### PR DESCRIPTION
* Add `SolverConfiguration.ShowConstructorElapsedTime` to allow measuring constructor time (closes #39).
* Add `SolverConfiguration.ShowTotalElapsedTimePerDay` to aggregate constructor, part1 & part2 times (as it's done to calculate the mean time per day in the overall results panel).

Using both options unveil #43, but since that was already there when solving a lot of problems, I'll be releasing these options anyway.