### PR TITLE
Fix `Solver.FormatTime` formatting when time > 1min

### DIFF
--- a/src/AoCHelper/Solver.cs
+++ b/src/AoCHelper/Solver.cs
@@ -335,7 +335,7 @@ namespace AoCHelper
                     < 1 => $"{elapsedMilliseconds:F} ms",
                     < 1_000 => $"{Math.Round(elapsedMilliseconds)} ms",
                     < 60_000 => $"{0.001 * elapsedMilliseconds:F} s",
-                    _ => $"{elapsedMilliseconds / 60_000} min {Math.Round(0.001 * (elapsedMilliseconds % 60_000))} s",
+                    _ => $"{Math.Floor(elapsedMilliseconds / 60_000)} min {Math.Round(0.001 * (elapsedMilliseconds % 60_000))} s",
                 }
                 : elapsedMilliseconds switch
                 {


### PR DESCRIPTION
* Fix `Solver.FormatTime` formatting when time > 1min.

Given 61_000ms:
* Before: `1.0167 min 1 s`
* After: `1 min 1 s`