### PR TITLE
🐛 Fix autoclear issue

### DIFF
--- a/src/AoCHelper/Solver.cs
+++ b/src/AoCHelper/Solver.cs
@@ -201,7 +201,7 @@ namespace AoCHelper
             var table = GetTable();
 
             await AnsiConsole.Live(table)
-                .AutoClear(true)
+                .AutoClear(false)
                 .Overflow(configuration.VerticalOverflow)
                 .Cropping(configuration.VerticalOverflowCropping)
                 .StartAsync(async ctx =>


### PR DESCRIPTION
`AnsiConsole.Live`'s `Autoclear` option was set to true in `SolveAll` method, which caused the problem results to be cleared before the general results panel is rendered.