### PR TITLE
Ensure `Markup` is escaped for rendered solution text

### DIFF
--- a/src/AoCHelper/Solver.cs
+++ b/src/AoCHelper/Solver.cs
@@ -633,7 +633,7 @@ namespace AoCHelper
         {
             var formattedTime = FormatTime(elapsedMilliseconds, configuration);
 
-            table.AddRow(problemTitle, part, solution, formattedTime);
+            table.AddRow(problemTitle, part, solution.EscapeMarkup(), formattedTime);
         }
 
         private static void RenderOverallResultsPanel(List<ElapsedTime> totalElapsedTime, SolverConfiguration configuration)


### PR DESCRIPTION
Ensure `Markup` is escaped for the solution text rendered in the table
This will prevent crashes when rendering exception messages/stacktraces.
This closes #47 and #138

Before:
```bash
┌───────┬──────────┬─────────────┬──────────────┐
│ Day   │ Part     │ Solution    │ Elapsed time │
├───────┼──────────┼─────────────┼──────────────┤
│ Day 1 │ Day_01() │ ----------- │ 47,6 ms      │
│ Day 1 │ Part 1   │ 66719       │ 6,5 ms       │
│ Day 1 │ Part 2   │ 198551      │ 4,4 ms       │
│ Day 1 │ Total    │ ----------- │ 58,6 ms      │
│       │          │             │              │
│ Day 2 │ Day_02() │ ----------- │ 0,9 ms       │
│ Day 2 │ Part 1   │ 11449       │ 1,8 ms       │
│ Day 2 │ Part 2   │ 13187       │ 1,3 ms       │
│ Day 2 │ Total    │ ----------- │ 3,9 ms       │
│       │          │             │              │
└───────┴──────────┴─────────────┴──────────────┘
Unhandled exception. System.InvalidOperationException: Could not find color or style 'TSource'.
   at Spectre.Console.StyleParser.Parse(String text) in /_/src/Spectre.Console/StyleParser.cs:line 10
   at Spectre.Console.MarkupParser.Parse(String text, Style style) in /_/src/Spectre.Console/Internal/Text/Markup/MarkupParser.cs:line 29
   at Spectre.Console.Markup..ctor(String text, Style style) in /_/src/Spectre.Console/Widgets/Markup.cs:line 42
   at Spectre.Console.TableExtensions.<>c.<AddRow>b__6_0(String column) in /_/src/Spectre.Console/Extensions/TableExtensions.cs:line 160
   at System.Linq.Enumerable.SelectArrayIterator`2.ToArray()
   at Spectre.Console.TableExtensions.AddRow(Table table, String[] columns) in /_/src/Spectre.Console/Extensions/TableExtensions.cs:line 160
   at AoCHelper.Solver.RenderRow(Table table, String problemTitle, String part, String solution, Double elapsedMilliseconds, SolverConfiguration configuration)
   at AoCHelper.Solver.SolveProblem(BaseProblem problem, Table table, Double constructorElapsedTime, SolverConfiguration configuration)
   at AoCHelper.Solver.<>c__DisplayClass8_0.<<SolveAll>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at Spectre.Console.LiveDisplay.<>c__DisplayClass17_0.<<StartAsync>b__0>d.MoveNext() in /_/src/Spectre.Console/Live/LiveDisplay.cs:line 80
--- End of stack trace from previous location ---
   at Spectre.Console.LiveDisplay.<>c__DisplayClass18_0`1.<<StartAsync>b__0>d.MoveNext() in /_/src/Spectre.Console/Live/LiveDisplay.cs:line 110
--- End of stack trace from previous location ---
   at Spectre.Console.Internal.DefaultExclusivityMode.RunAsync[T](Func`1 func) in /_/src/Spectre.Console/Internal/DefaultExclusivityMode.cs:line 40
   at Spectre.Console.LiveDisplay.StartAsync[T](Func`2 func) in /_/src/Spectre.Console/Live/LiveDisplay.cs:line 98
   at Spectre.Console.LiveDisplay.StartAsync(Func`2 func) in /_/src/Spectre.Console/Live/LiveDisplay.cs:line 78
   at AoCHelper.Solver.SolveAll(Action`1 options)
   at Program.<Main>$(String[] args) in C:\dev\_forks\tmp\Advent_of_Code\2022\Program.cs:line 9
   at Program.<Main>(String[] args)

```

After:
```bash
┌───────┬──────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬──────────────┐
│ Day   │ Part     │ Solution                                                                                                                                │ Elapsed time │
├───────┼──────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────────┤
│ Day 1 │ Day_01() │ -----------                                                                                                                             │ 66,5 ms      │
│ Day 1 │ Part 1   │ 66719                                                                                                                                   │ 4,0 ms       │
│ Day 1 │ Part 2   │ 198551                                                                                                                                  │ 3,0 ms       │
│ Day 1 │ Total    │ -----------                                                                                                                             │ 73,5 ms      │
│       │          │                                                                                                                                         │              │
│ Day 2 │ Day_02() │ -----------                                                                                                                             │ 1,4 ms       │
│ Day 2 │ Part 1   │ 11449                                                                                                                                   │ 1,7 ms       │
│ Day 2 │ Part 2   │ 13187                                                                                                                                   │ 1,3 ms       │
│ Day 2 │ Total    │ -----------                                                                                                                             │ 4,4 ms       │
│       │          │                                                                                                                                         │              │
│ Day 3 │ Day_03() │ -----------                                                                                                                             │ 0,7 ms       │
│ Day 3 │ Part 1   │ Value cannot be null. (Parameter 'source')                                                                                              │ 50,6 ms      │
│       │          │    at System.Linq.ThrowHelper.ThrowArgumentNullException(ExceptionArgument argument)                                                    │              │
│       │          │    at System.Linq.Enumerable.ToHashSet[TSource](IEnumerable`1 source, IEqualityComparer`1 comparer)                                     │              │
│       │          │    at System.Linq.Enumerable.ToHashSet[TSource](IEnumerable`1 source)                                                                   │              │
│       │          │    at AoC_2022.Days.Day_03.PriorityOfCommonItem(NonEmptyList`1 parts) in C:\dev\_forks\tmp\Advent_of_Code\2022\Days\Day_03.cs:line 31   │              │
│       │          │    at System.Linq.Enumerable.Sum[TSource,TResult,TAccumulator](IEnumerable`1 source, Func`2 selector)                                   │              │
│       │          │    at AoC_2022.Days.Day_03.Solve_1() in C:\dev\_forks\tmp\Advent_of_Code\2022\Days\Day_03.cs:line 17                                    │              │
│       │          │    at AoCHelper.Solver.SolvePart(Boolean isPart1, BaseProblem problem) in C:\dev\_forks\tmp\Advent_of_Code\AoCHelper\Solver.cs:line 552 │              │
│ Day 3 │ Part 2   │ Enumeration has not started. Call MoveNext.                                                                                             │ 4,3 ms       │
│       │          │    at System.SZGenericArrayEnumerator`1.get_Current()                                                                                   │              │
│       │          │    at Core.LinqHelpers.FirstAndRest[T](IEnumerable`1 source) in C:\dev\_forks\tmp\Advent_of_Code\Core\Core\LinqHelpers.cs:line 502      │              │
│       │          │    at Core.NonEmptyList`1..ctor(IEnumerable`1 source) in C:\dev\_forks\tmp\Advent_of_Code\Core\Core\NonEmptyList.cs:line 28             │              │
│       │          │    at Core.NonEmptyList.Create[T](IEnumerable`1 items) in C:\dev\_forks\tmp\Advent_of_Code\Core\Core\NonEmptyList.cs:line 11            │              │
│       │          │    at System.Linq.Enumerable.SelectEnumerableIterator`2.MoveNext()                                                                      │              │
│       │          │    at System.Linq.Enumerable.Sum[TSource,TResult,TAccumulator](IEnumerable`1 source, Func`2 selector)                                   │              │
│       │          │    at AoC_2022.Days.Day_03.Solve_2() in C:\dev\_forks\tmp\Advent_of_Code\2022\Days\Day_03.cs:line 24                                    │              │
│       │          │    at AoCHelper.Solver.SolvePart(Boolean isPart1, BaseProblem problem) in C:\dev\_forks\tmp\Advent_of_Code\AoCHelper\Solver.cs:line 552 │              │
│ Day 3 │ Total    │ -----------                                                                                                                             │ 55,6 ms      │
│       │          │                                                                                                                                         │              │
│ Day 4 │ Day_04() │ -----------                                                                                                                             │ 34,5 ms      │
│ Day 4 │ Part 1   │ 526                                                                                                                                     │ 6,4 ms       │
│ Day 4 │ Part 2   │ 886                                                                                                                                     │ 2,2 ms       │
│ Day 4 │ Total    │ -----------                                                                                                                             │ 43,1 ms      │
│       │          │                                                                                                                                         │              │
│ Day 5 │ Day_05() │ -----------                                                                                                                             │ 33,4 ms      │
│ Day 5 │ Part 1   │ BSDMQFLSP                                                                                                                               │ 12,5 ms      │
│ Day 5 │ Part 2   │ PGSQBFLDP                                                                                                                               │ 1,9 ms       │
│ Day 5 │ Total    │ -----------                                                                                                                             │ 47,9 ms      │
│       │          │                                                                                                                                         │              │
│ Day 6 │ Day_06() │ -----------                                                                                                                             │ 1,0 ms       │
│ Day 6 │ Part 1   │ 1100                                                                                                                                    │ 11,5 ms      │
│ Day 6 │ Part 2   │ 2421                                                                                                                                    │ 3,3 ms       │
│ Day 6 │ Total    │ -----------                                                                                                                             │ 15,8 ms      │
│       │          │                                                                                                                                         │              │
│ Day 7 │ Day_07() │ -----------                                                                                                                             │ 1,0 ms       │
│ Day 7 │ Part 1   │ 1297683                                                                                                                                 │ 12,1 ms      │
│ Day 7 │ Part 2   │ 5756764                                                                                                                                 │ 2,7 ms       │
│ Day 7 │ Total    │ -----------                                                                                                                             │ 15,9 ms      │
│       │          │                                                                                                                                         │              │
└───────┴──────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴──────────────┘
┌─────── Overall results ────────┐
│                                │
│ Total (7 days)        256,2 ms │
│ Total constructors    138,6 ms │
│ Total parts 1         98,8 ms  │
│ Total parts 2         18,8 ms  │
│                                │
│ Mean (per day)        36,6 ms  │
│ Mean constructors     19,8 ms  │
│ Mean parts 1          14,1 ms  │
│ Mean parts 2          2,7 ms   │
└────────────────────────────────┘

```